### PR TITLE
Fix package dependency errors

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,16 +38,7 @@ fi
 
 # Install all necessary pip packages
 
-sudo pip3 install readline
-sudo pip3 install binascii
-sudo pip3 install struct
-sudo pip3 install textwrap
-sudo pip3 install multiprocessing
-sudo pip3 install threading
-sudo pip3 install queue
-sudo pip3 install subprocess
-sudo pip3 install time
-
+sudo pip3 install gnureadline
 sudo pip3 install colorama
 
 sudo pip3 install ipaddress


### PR DESCRIPTION
This fixes the errors when installing the dependencies. I tested all the features with Python 3.10 on an Ubuntu machine and the program ran it well. Most packages that I removed are already built-in packages in newer Python versions, so it's not necessary to install them. Also, [readline](https://pypi.org/project/readline/) was renamed to `gnureadline`.

Closes #3 
